### PR TITLE
Adding conventional commit docker build reusable workflow

### DIFF
--- a/.github/workflows/docker-build-conventional.yml
+++ b/.github/workflows/docker-build-conventional.yml
@@ -1,0 +1,70 @@
+on:
+  workflow_call:
+    inputs:
+      directory:
+        required: false
+        default: ./
+        type: string
+        description: "Path of directory from project root, containing the Dockerfile to build. Useful for mono-repos."
+      imageName:
+        required: true
+        type: string
+        description: "Full repository and image name to publish as. Example 'ghcr.io/my-repository/image'."
+      tagPrefix:
+        required: false
+        type: string
+        description: "Prefix to use for git tags. Will be joined appended with `-v0.0.0` semver. Example 'my-image'."
+jobs:
+  release:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set Git config
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Conventional Commit Tag
+        id: conventional_commit_tag
+        run: |
+          cat <<EOF > .versionrc
+          {
+              "bumpFiles": [],
+              "packageFiles": [],
+              "skip": {
+                "commit": true,
+                "changelog": true
+              }
+          }
+          EOF
+          npx standard-version --tag-prefix "${{ inputs.tagPrefix }}-v" --path "${{ inputs.directory }}"
+          tag=$(git describe --tags --abbrev=0 | sed "s/${{ inputs.tagPrefix }}-//")
+          echo "::set-output name=tag::$tag"
+      
+      - name: Build and Push
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ inputs.directory }}
+          push: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main')}}
+          tags: ${{ inputs.imageName }}:latest,${{ inputs.imageName }}:${{ steps.conventional_commit_tag.outputs.tag }}
+
+      - name: Push Git Tag
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main')}}
+        run: git push --tags


### PR DESCRIPTION
- Moving the workflow to a publically available location.
- The only change here was to support a local directory (root dir of the repo) as a default.  