### PR TITLE
Switching from run-all

### DIFF
--- a/.github/workflows/terragrunt-apply-azure.yml
+++ b/.github/workflows/terragrunt-apply-azure.yml
@@ -17,26 +17,6 @@ on:
         required: true
 
 jobs:
-  validate:
-    name: "Terraform fmt & validate"
-    runs-on:
-      - self-hosted
-      - terraform-1.0
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Terraform fmt check
-        run: terraform fmt -check -recursive -diff
-
-      - name: Terraform validate
-        run: terraform validate
-        env:
-          ARM_CLIENT_ID : ${{ secrets.ARM_CLIENT_ID }}
-          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-          TF_VAR_arm_subscription_id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-          TF_VAR_arm_tenant_id: ${{ secrets.ARM_TENANT_ID }}
-  
   apply:
     name: Terraform Apply
     runs-on:
@@ -48,7 +28,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Terragrunt apply
-        run: yes | terragrunt run-all apply --terragrunt-working-dir ${{ inputs.workingDirectory }}
+        run: terragrunt apply -auto-approve --terragrunt-working-dir ${{ inputs.workingDirectory }}
         env:
           ARM_CLIENT_ID : ${{ secrets.ARM_CLIENT_ID }}
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}

--- a/.github/workflows/terragrunt-apply-azure.yml
+++ b/.github/workflows/terragrunt-apply-azure.yml
@@ -32,5 +32,5 @@ jobs:
         env:
           ARM_CLIENT_ID : ${{ secrets.ARM_CLIENT_ID }}
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-          TF_VAR_arm_subscription_id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-          TF_VAR_arm_tenant_id: ${{ secrets.ARM_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}

--- a/.github/workflows/terragrunt-plan-azure.yml
+++ b/.github/workflows/terragrunt-plan-azure.yml
@@ -30,7 +30,7 @@ jobs:
         run: terraform fmt -check -recursive -diff
 
       - name: Terraform validate
-        run: terraform validate
+        run: terragrunt validate --terragrunt-working-dir ${{ inputs.workingDirectory }}
         env:
           ARM_CLIENT_ID : ${{ secrets.ARM_CLIENT_ID }}
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
@@ -52,7 +52,7 @@ jobs:
       - name: Terragrunt plan
         run: |
           set -o pipefail
-          terragrunt run-all plan --terragrunt-working-dir ${{ inputs.workingDirectory }} | tee logs.txt
+          terragrunt plan --terragrunt-working-dir ${{ inputs.workingDirectory }} | tee logs.txt
           echo "##[set-output name=modified_terraform;]$(cat logs.txt | grep "No changes. Infrastructure is up-to-date." || true)"
         id: plan
         env:

--- a/.github/workflows/terragrunt-plan-azure.yml
+++ b/.github/workflows/terragrunt-plan-azure.yml
@@ -34,8 +34,8 @@ jobs:
         env:
           ARM_CLIENT_ID : ${{ secrets.ARM_CLIENT_ID }}
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-          TF_VAR_arm_subscription_id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-          TF_VAR_arm_tenant_id: ${{ secrets.ARM_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
   
   plan:
     name: Terraform Plan
@@ -58,8 +58,8 @@ jobs:
         env:
           ARM_CLIENT_ID : ${{ secrets.ARM_CLIENT_ID }}
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-          TF_VAR_arm_subscription_id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-          TF_VAR_arm_tenant_id: ${{ secrets.ARM_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
   
   pullRequestComment:
     name: Comment on PR


### PR DESCRIPTION
* making workflows affect a single terragrunt config instead of 'all'
* removing validation from apply since we're validating in plan
* using terragrunt for `validate`
* standardizing on environment variable config for provider/backend instead of half using tf vars